### PR TITLE
Better error handling in MPI context

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    types: [synchronize]
+    types: [opened, synchronize]
   push:
     branches:
       - main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: 3.10.0
+  rev: 3.12.0
   hooks:
   - id: commitizen
     stages: [commit-msg]
@@ -12,7 +12,7 @@ repos:
 #     - id: poetry-export
 #       args: ["-f", "requirements.txt", "-o", "requirements.txt"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.5.1  # Use the sha / tag you want to point at
+  rev: v1.6.1  # Use the sha / tag you want to point at
   hooks:
   - id: mypy
     additional_dependencies: [types-all]
@@ -36,7 +36,7 @@ repos:
     - id: isort
       name: isort (python)
 - repo: https://github.com/psf/black
-  rev: 23.9.1
+  rev: 23.10.1
   hooks:
   - id: black
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/perun/backend/nvml.py
+++ b/perun/backend/nvml.py
@@ -26,7 +26,7 @@ class NVMLBackend(Backend):
 
     def setup(self):
         """Init pynvml and gather number of devices."""
-        self.pynvml = importlib.import_module("pynmvl")
+        self.pynvml = importlib.import_module("pynvml")
         self.pynvml.nvmlInit()
         deviceCount = self.pynvml.nvmlDeviceGetCount()
         self.metadata = {

--- a/perun/comm.py
+++ b/perun/comm.py
@@ -66,3 +66,8 @@ class Comm:
         """MPI barrier operation."""
         if self._enabled:
             self._comm.barrier()
+
+    def Abort(self, errorcode: int):
+        """MPI Abort operation."""
+        if self._enabled:
+            self._comm.Abort(errorcode=errorcode)

--- a/perun/perun.py
+++ b/perun/perun.py
@@ -1,4 +1,5 @@
 """Core perun functionality."""
+import logging
 import os
 import platform
 import pprint as pp
@@ -11,7 +12,7 @@ from multiprocessing import Event, Process, Queue
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Type
 
-from perun import __version__, log
+from perun import __version__
 from perun.backend.backend import Backend
 from perun.backend.nvml import NVMLBackend
 from perun.backend.powercap_rapl import PowercapRAPLBackend
@@ -25,6 +26,8 @@ from perun.io.io import IOFormat, exportTo, importFrom
 from perun.processing import processDataNode
 from perun.subprocess import perunSubprocess
 from perun.util import getRunId, getRunName, increaseIdCounter, singleton
+
+log = logging.getLogger("perun")
 
 
 @singleton

--- a/perun/perun.py
+++ b/perun/perun.py
@@ -335,7 +335,17 @@ class Perun:
                 log.error(
                     f"Rank {self.comm.Get_rank()}:  Found error on monitored script: {str(app)}"
                 )
+                start_event.set()
                 stop_event.set()
+                log.error(
+                    f"Rank {self.comm.Get_rank()}:  Set start and stop event forcefully"
+                )
+                if perunSP:
+                    perunSP.terminate()
+                    log.error(f"Rank {self.comm.Get_rank()}: Terminating subprocess")
+
+                self.comm.Abort(1)
+                log.error(f"Rank {self.comm.Get_rank()}:  Aborting mpi context.")
                 raise e
 
             # 4) App finished, stop subrocess and get data

--- a/perun/perun.py
+++ b/perun/perun.py
@@ -335,6 +335,9 @@ class Perun:
                 log.error(
                     f"Rank {self.comm.Get_rank()}:  Found error on monitored script: {str(app)}"
                 )
+                s, r = getattr(e, "message", str(e)), getattr(e, "message", repr(e))
+                log.error(f"Rank {self.comm.Get_rank()}: {s}")
+                log.error(f"Rank {self.comm.Get_rank()}: {r}")
                 start_event.set()
                 stop_event.set()
                 log.error(


### PR DESCRIPTION
Errors inside the script failed to properly release the MPI context and close the monitoring subprocess, creating a situation where scripts waited endlessly to close. This should avoid those problems with script crashes.