### PR TITLE
Python 3.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,9 @@ dmypy.json
 # Custom
 .vscode
 *.out
-poetry.lock
+*.lock
 .perun.ini
 examples/data
 examples/**/perun_results
+.pdm-python
+perun_results/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,62 +1,63 @@
-[tool.poetry]
+[project]
 name = "perun"
 version = "0.5.0"
-description = ""
-authors = ["Gutiérrez Hermosillo Muriedas, Juan Pedro <juanpedroghm@gmail.com>"]
-license = "BSD-3-Clause"
+description = "Command line tool to easily estimate energy consumption of python applications."
+authors = [
+    {name = "Gutiérrez Hermosillo Muriedas, Juan Pedro", email = "juanpedroghm@gmail.com"},
+]
+dependencies = [
+    "py-cpuinfo>=6.0.0",
+    "numpy>=1.23",
+    "psutil>=5.9.0",
+    "h5py<4.0.0,>=3.2.0",
+    "pandas>=1.3",
+    "tabulate>=0.9",
+]
+requires-python = ">=3.8,<3.13"
 readme = "README.md"
+license = {text = "BSD-3-Clause"}
+
+[project.urls]
 homepage = "https://github.com/Helmholtz-AI-Energy/perun"
 
-[tool.poetry.scripts]
+[project.optional-dependencies]
+mpi = ["mpi4py<4.0,>=3.1"]
+nvidia = ["nvidia-ml-py<13.0.0,>=12.535.77"]
+rocm = ["pyrsmi<2.0.0,>=1.0.1"]
+
+[project.scripts]
 perun = "perun.api.cli:cli"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<4.0"
-py-cpuinfo = ">=5.0.0"
-numpy = ">=1.20.0"
-psutil = "^5.9.0"
-h5py = "^3.5.9"
-pandas = {version = ">=1.3"}
-tabulate = ">=0.9"
-mpi4py = {version = "^3.1", optional = true }
-nvidia-ml-py = {version = "^12.535.77", optional = true }
-pyrsmi = {version = "^1.0.1", optional = true }
+[tool.pdm.build]
+includes = []
 
-[tool.poetry.extras]
-mpi = ["mpi4py"]
-nvidia = ["nvidia-ml-py"]
-rocm = ["pyrsmi"]
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
-[tool.poetry.group.dev]
-optional = true
+[tool.pdm]
+distribution = true
 
-[tool.poetry.group.dev.dependencies]
-pytest = "*"
-pytest-cov = "*"
-flake8 = "*"
-mypy = "*"
-black = "*"
-pre-commit = "*"
-pydocstyle = "*"
-python-semantic-release = "^8.1.1"
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-sphinx = "*"
-sphinx-rtd-theme = "*"
-sphinx-autoapi = "*"
-
-[tool.poetry.group.mpi]
-optional = true
-
-[tool.poetry.group.mpi.dependencies]
-mpi4py = "^3.1"
+[tool.pdm.dev-dependencies]
+dev = [
+    "pytest>=6.0.0",
+    "pytest-cov",
+    "flake8>=4.0.0",
+    "mypy>=1.0.0",
+    "black>=22.0.0",
+    "pre-commit>=3.0.0",
+    "pydocstyle",
+    "python-semantic-release>=8.0.0",
+]
+docs = [
+    "sphinx>=7.0.0",
+    "sphinx-rtd-theme>=2.0.0",
+    "sphinx-autoapi",
+]
 
 [tool.semantic_release]
 version_variables = [ "perun/__init__.py:__version__", "docs/conf.py:release" ]
-version_toml = ["pyproject.toml:tool.poetry.version"]
+version_toml = ["pyproject.toml:project.version"]
 commit_message = "{version} [skip ci]"
 
 [tool.semantic_release.remote.token]
@@ -81,10 +82,6 @@ profile = "black"
 [tool.pydocstyle]
 match-dir = 'perun'
 convention = 'numpy'
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [


### PR DESCRIPTION
Attempted to add support to it through pdm, because poetry was not cooperating. I might not go with it, I don't like the venv management aspect very much, but I just might need to get used to. Otherwise, it might be better to just use *setuptools* 

Turns out, the problem is numpy, that will not allow the library to support py3.8 and py3.12. I don't want to drop support for 3.8 yet, as it is still officially supported with security updates, and a lot of projects probably still use 3.8. But there is a change, I might lose users that want to use the latest updates for development. 

Need to look more into this, there might be some special configuration for either poetry or pdm. 