### PR TITLE
test: add hardware-independent unit tests for all backends

### DIFF
--- a/tests/perun/backend/test_nvml.py
+++ b/tests/perun/backend/test_nvml.py
@@ -1,0 +1,188 @@
+"""Unit tests for the NVML (NVIDIA) backend using a fake ``pynvml`` module.
+
+The backend imports ``pynvml`` lazily via ``importlib.import_module``. We inject
+a fake module into ``sys.modules`` so the backend can be exercised without an
+NVIDIA GPU or the real bindings installed.
+"""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from perun.data_model.measurement_type import Unit
+from perun.data_model.sensor import DeviceType
+
+
+class _NVMLError(Exception):
+    pass
+
+
+class _NVMLErrorUninitialized(_NVMLError):
+    pass
+
+
+class _MemoryInfo:
+    def __init__(self, total, used):
+        self.total = total
+        self.used = used
+
+
+def _make_fake_pynvml(device_count=2, power=150000, mem_used=1024, mem_total=8192):
+    """Build a minimal fake ``pynvml`` module driving the NVML backend."""
+    mod = types.ModuleType("pynvml")
+
+    mod.NVMLError = _NVMLError
+    mod.NVMLError_Uninitialized = _NVMLErrorUninitialized
+    mod.NVML_CLOCK_SM = 0
+    mod.NVML_CLOCK_MEM = 1
+    mod.NVML_CLOCK_GRAPHICS = 2
+
+    state = {"init_calls": 0, "shutdown_calls": 0}
+    mod._state = state
+
+    def nvmlInit():
+        state["init_calls"] += 1
+
+    def nvmlShutdown():
+        state["shutdown_calls"] += 1
+
+    def nvmlDeviceGetCount():
+        return device_count
+
+    def nvmlSystemGetCudaDriverVersion():
+        return 12040
+
+    def nvmlSystemGetDriverVersion():
+        return "550.00"
+
+    def nvmlDeviceGetHandleByIndex(i):
+        if i >= device_count:
+            raise _NVMLError(f"no device {i}")
+        return {"index": i}
+
+    def nvmlDeviceGetPowerUsage(handle):
+        return power
+
+    def nvmlDeviceGetMemoryInfo(handle):
+        return _MemoryInfo(mem_total, mem_used)
+
+    def nvmlDeviceGetClockInfo(handle, clock_id):
+        return 1000 + clock_id
+
+    def nvmlDeviceGetMaxClockInfo(handle, clock_id):
+        return 2000 + clock_id
+
+    def nvmlDeviceGetUUID(handle):
+        return f"GPU-uuid-{handle['index']}"
+
+    def nvmlDeviceGetName(handle):
+        return f"FakeGPU{handle['index']}"
+
+    def nvmlDeviceGetPowerManagementDefaultLimit(handle):
+        return 300000
+
+    mod.nvmlInit = nvmlInit
+    mod.nvmlShutdown = nvmlShutdown
+    mod.nvmlDeviceGetCount = nvmlDeviceGetCount
+    mod.nvmlSystemGetCudaDriverVersion = nvmlSystemGetCudaDriverVersion
+    mod.nvmlSystemGetDriverVersion = nvmlSystemGetDriverVersion
+    mod.nvmlDeviceGetHandleByIndex = nvmlDeviceGetHandleByIndex
+    mod.nvmlDeviceGetPowerUsage = nvmlDeviceGetPowerUsage
+    mod.nvmlDeviceGetMemoryInfo = nvmlDeviceGetMemoryInfo
+    mod.nvmlDeviceGetClockInfo = nvmlDeviceGetClockInfo
+    mod.nvmlDeviceGetMaxClockInfo = nvmlDeviceGetMaxClockInfo
+    mod.nvmlDeviceGetUUID = nvmlDeviceGetUUID
+    mod.nvmlDeviceGetName = nvmlDeviceGetName
+    mod.nvmlDeviceGetPowerManagementDefaultLimit = (
+        nvmlDeviceGetPowerManagementDefaultLimit
+    )
+    return mod
+
+
+@pytest.fixture()
+def fake_pynvml(monkeypatch, setup_cleanup):
+    mod = _make_fake_pynvml()
+    monkeypatch.setitem(sys.modules, "pynvml", mod)
+    return mod
+
+
+@pytest.fixture()
+def backend(fake_pynvml):
+    from perun.backend.nvml import NVMLBackend
+
+    b = NVMLBackend()
+    yield b
+    b.close()
+
+
+def test_setup_metadata(backend):
+    md = backend.metadata
+    assert md["source"] == "Nvidia Managment Library"
+    assert "cuda_version" in md
+    assert "driver_version" in md
+
+
+def test_available_sensors_power_mem_clocks(backend):
+    sensors = backend.availableSensors()
+    # 2 devices * (power + mem + 3 clocks) = 10 sensors.
+    assert len(sensors) == 2 * 5
+    assert "CUDA:0_POWER" in sensors
+    assert "CUDA:0_MEM" in sensors
+    assert any(k.startswith("CUDA:0_CLOCK") for k in sensors)
+
+
+def test_available_sensors_units(backend):
+    sensors = backend.availableSensors()
+    assert sensors["CUDA:0_POWER"][2] == Unit.WATT
+    assert sensors["CUDA:0_MEM"][2] == Unit.BYTE
+
+
+def test_power_sensor_reads(backend):
+    (sensor,) = backend.getSensors({"CUDA:0_POWER"})
+    assert sensor.type == DeviceType.GPU
+    assert sensor.dataType.unit == Unit.WATT
+    assert int(sensor.read()) == 150000
+
+
+def test_memory_sensor_reads_uint64(backend):
+    (sensor,) = backend.getSensors({"CUDA:1_MEM"})
+    value = sensor.read()
+    assert value.dtype == np.uint64
+    assert int(value) == 1024
+
+
+def test_clock_sensor_reads(backend):
+    clock_id = next(k for k in backend.availableSensors() if "CLOCK_SM" in k)
+    (sensor,) = backend.getSensors({clock_id})
+    assert sensor.type == DeviceType.GPU
+    assert sensor.dataType.unit == Unit.HZ
+    # Fake returns 1000 + clock index; SM clock id is 0.
+    assert int(sensor.read()) == 1000
+
+
+def test_power_callback_error_returns_zero(backend, fake_pynvml):
+    (sensor,) = backend.getSensors({"CUDA:0_POWER"})
+
+    def boom(handle):
+        raise fake_pynvml.NVMLError("read failure")
+
+    fake_pynvml.nvmlDeviceGetPowerUsage = boom
+    assert int(sensor.read()) == 0
+
+
+def test_mem_callback_error_returns_uint64_zero(backend, fake_pynvml):
+    (sensor,) = backend.getSensors({"CUDA:0_MEM"})
+
+    def boom(handle):
+        raise fake_pynvml.NVMLError("read failure")
+
+    fake_pynvml.nvmlDeviceGetMemoryInfo = boom
+    value = sensor.read()
+    assert int(value) == 0
+
+
+def test_close_calls_shutdown(backend, fake_pynvml):
+    backend.close()
+    assert fake_pynvml._state["shutdown_calls"] >= 1

--- a/tests/perun/backend/test_powercap_rapl.py
+++ b/tests/perun/backend/test_powercap_rapl.py
@@ -1,0 +1,112 @@
+"""Unit tests for the Powercap RAPL backend.
+
+The backend reads energy counters from the Linux powercap sysfs hierarchy
+(``/sys/class/powercap``). To keep the tests hardware independent we build a
+fake sysfs tree under ``tmp_path`` and point the backend at it via the
+module-level ``RAPL_PATH``.
+"""
+
+import numpy as np
+import pytest
+
+import perun.backend.powercap_rapl as rapl_mod
+from perun.backend.powercap_rapl import PowercapRAPLBackend
+from perun.data_model.measurement_type import Unit
+from perun.data_model.sensor import DeviceType
+
+
+def _write(path, content):
+    path.write_text(str(content))
+
+
+def _make_package(root, socket, package_energy=1000, dram_energy=500):
+    """Create an ``intel-rapl:<socket>`` package with a nested dram subdomain."""
+    pkg = root / f"intel-rapl:{socket}"
+    pkg.mkdir()
+    _write(pkg / "name", f"package-{socket}")
+    _write(pkg / "energy_uj", package_energy)
+    _write(pkg / "max_energy_range_uj", 262143328850)
+
+    dram = pkg / f"intel-rapl:{socket}:0"
+    dram.mkdir()
+    _write(dram / "name", "dram")
+    _write(dram / "energy_uj", dram_energy)
+    _write(dram / "max_energy_range_uj", 65712999613)
+    return pkg
+
+
+@pytest.fixture()
+def fake_rapl(tmp_path, monkeypatch, setup_cleanup):
+    """Create a fake powercap tree and point the backend at it."""
+    powercap = tmp_path / "powercap"
+    powercap.mkdir()
+    _make_package(powercap, 0)
+    _make_package(powercap, 1)
+    monkeypatch.setattr(rapl_mod, "RAPL_PATH", str(powercap))
+    return powercap
+
+
+@pytest.fixture()
+def backend(fake_rapl):
+    b = PowercapRAPLBackend()
+    yield b
+    b.close()
+
+
+def test_setup_discovers_package_and_dram(backend):
+    sensors = backend.availableSensors()
+    # 2 sockets x (package + dram) = 4 devices.
+    assert len(sensors) == 4
+    types = {meta[1] for meta in sensors.values()}
+    assert DeviceType.CPU in types
+    assert DeviceType.RAM in types
+
+
+def test_available_sensors_units_are_joule(backend):
+    for _, (backend_id, _dev_type, unit) in backend.availableSensors().items():
+        assert backend_id == backend.id
+        assert unit == Unit.JOULE
+
+
+def test_get_sensors_and_read(backend):
+    ids = set(backend.availableSensors().keys())
+    sensors = backend.getSensors(ids)
+    assert {s.id for s in sensors} == ids
+    for sensor in sensors:
+        value = sensor.read()
+        assert np.issubdtype(np.asarray(value).dtype, np.integer)
+        assert value >= 0
+
+
+def test_callback_reads_current_file_value(backend, fake_rapl):
+    ids = list(backend.availableSensors().keys())
+    # Sensor ids have the form "cpu_<socket>_package-<socket>"; pick a package
+    # sensor and derive its backing energy file from the socket number so the
+    # test targets the exact file that sensor reads from.
+    package_id = next(i for i in ids if i.startswith("cpu_"))
+    socket = package_id.split("_")[1]
+    (sensor,) = backend.getSensors({package_id})
+
+    first = int(sensor.read())
+    # Simulate the counter advancing on disk and confirm the callback re-reads.
+    # The backend keeps the file handle open and seeks to 0, so we must update
+    # the file in place (truncating the same inode) rather than replacing it.
+    pkg_energy_file = fake_rapl / f"intel-rapl:{socket}" / "energy_uj"
+    with open(pkg_energy_file, "r+") as fh:
+        fh.seek(0)
+        fh.truncate()
+        fh.write(str(first + 12345))
+    second = int(sensor.read())
+    assert second == first + 12345
+
+
+def test_missing_powercap_raises_import_warning(tmp_path, monkeypatch, setup_cleanup):
+    monkeypatch.setattr(rapl_mod, "RAPL_PATH", str(tmp_path / "does_not_exist"))
+    with pytest.raises(ImportWarning):
+        PowercapRAPLBackend()
+
+
+def test_close_closes_files(backend):
+    backend.close()
+    for f in backend._files:
+        assert f.closed

--- a/tests/perun/backend/test_psutil.py
+++ b/tests/perun/backend/test_psutil.py
@@ -1,0 +1,77 @@
+"""Unit tests for the psutil backend.
+
+``psutil`` is a hard dependency of perun and is always importable, so these
+tests exercise the real backend and only patch the individual ``psutil``
+functions where a deterministic reading is required.
+"""
+
+import numpy as np
+import pytest
+
+from perun.backend.psutil import PSUTILBackend
+from perun.data_model.measurement_type import Unit
+from perun.data_model.sensor import DeviceType
+
+
+@pytest.fixture()
+def backend(setup_cleanup):
+    """Return a fresh PSUTILBackend instance (singletons reset by fixture)."""
+    return PSUTILBackend()
+
+
+def test_metadata_contains_source(backend):
+    assert "source" in backend.metadata
+    assert backend.metadata["source"].startswith("psutil")
+
+
+def test_available_sensors_shape(backend):
+    sensors = backend.availableSensors()
+    assert isinstance(sensors, dict)
+    assert len(sensors) > 0
+    for sensor_id, meta in sensors.items():
+        # (backend_id, DeviceType, Unit)
+        assert meta[0] == backend.id
+        assert isinstance(meta[1], DeviceType)
+        assert isinstance(meta[2], Unit)
+
+
+def test_ram_and_cpu_sensors_present(backend):
+    sensors = backend.availableSensors()
+    assert "RAM_USAGE" in sensors
+    assert any(s.startswith("CPU_USAGE_") for s in sensors)
+
+
+def test_get_sensors_returns_requested(backend):
+    available = set(backend.availableSensors().keys())
+    requested = {s for s in available if s == "RAM_USAGE" or s.startswith("CPU_USAGE_")}
+    sensors = backend.getSensors(requested)
+    returned_ids = {s.id for s in sensors}
+    assert returned_ids == requested
+
+
+def test_ram_sensor_reads_uint64(backend):
+    (sensor,) = backend.getSensors({"RAM_USAGE"})
+    assert sensor.type == DeviceType.RAM
+    assert sensor.dataType.unit == Unit.BYTE
+    value = sensor.read()
+    assert np.issubdtype(np.asarray(value).dtype, np.integer)
+    assert value >= 0
+
+
+def test_cpu_usage_sensor_reads_percent(backend):
+    cpu_ids = [s for s in backend.availableSensors() if s.startswith("CPU_USAGE_")]
+    (sensor,) = backend.getSensors({cpu_ids[0]})
+    assert sensor.type == DeviceType.CPU
+    assert sensor.dataType.unit == Unit.PERCENT
+    value = float(sensor.read())
+    assert 0.0 <= value <= 100.0
+
+
+def test_get_callback_invalid_device_raises(backend):
+    with pytest.raises(ValueError):
+        backend._getCallback("NOT_A_REAL_DEVICE")
+
+
+def test_close_is_noop(backend):
+    # Should not raise.
+    backend.close()

--- a/tests/perun/backend/test_rocmsmi.py
+++ b/tests/perun/backend/test_rocmsmi.py
@@ -1,0 +1,149 @@
+"""Unit tests for the ROCM (AMD) backend using a fake ``amdsmi`` module.
+
+The backend imports ``amdsmi`` lazily via ``importlib.import_module``. We inject
+a fake module into ``sys.modules`` so the backend can be exercised without an
+AMD GPU or the real bindings installed.
+"""
+
+import enum
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from perun.data_model.measurement_type import Unit
+from perun.data_model.sensor import DeviceType
+
+
+class _AmdSmiException(Exception):
+    pass
+
+
+class _AmdSmiMemoryType(enum.Enum):
+    VRAM = "vram"
+
+
+class _AmdSmiInitFlags(enum.Enum):
+    INIT_AMD_GPUS = 1
+
+
+def _make_fake_amdsmi(n_devices=2, power=120, mem_used=2048, mem_total=16384):
+    mod = types.ModuleType("amdsmi")
+    mod.AmdSmiException = _AmdSmiException
+    mod.AmdSmiMemoryType = _AmdSmiMemoryType
+    mod.AmdSmiInitFlags = _AmdSmiInitFlags
+
+    state = {"init_calls": 0, "shutdown_calls": 0}
+    mod._state = state
+
+    handles = [{"index": i} for i in range(n_devices)]
+
+    def amdsmi_init(flags):
+        state["init_calls"] += 1
+
+    def amdsmi_shut_down():
+        state["shutdown_calls"] += 1
+
+    def amdsmi_get_lib_version():
+        return {"major": 6, "minor": 2, "patch": 0}
+
+    def amdsmi_get_processor_handles():
+        return handles
+
+    def amdsmi_get_gpu_device_uuid(handle):
+        return f"amd-uuid-{handle['index']}"
+
+    def amdsmi_get_power_info(handle):
+        return {"average_socket_power": power, "power_limit": 300 * 10**6}
+
+    def amdsmi_get_gpu_board_info(handle):
+        return {"product_name": f"FakeAMD{handle['index']}"}
+
+    def amdsmi_get_gpu_memory_usage(handle, mem_type):
+        return mem_used
+
+    def amdsmi_get_gpu_memory_total(handle, mem_type):
+        return mem_total
+
+    mod.amdsmi_init = amdsmi_init
+    mod.amdsmi_shut_down = amdsmi_shut_down
+    mod.amdsmi_get_lib_version = amdsmi_get_lib_version
+    mod.amdsmi_get_processor_handles = amdsmi_get_processor_handles
+    mod.amdsmi_get_gpu_device_uuid = amdsmi_get_gpu_device_uuid
+    mod.amdsmi_get_power_info = amdsmi_get_power_info
+    mod.amdsmi_get_gpu_board_info = amdsmi_get_gpu_board_info
+    mod.amdsmi_get_gpu_memory_usage = amdsmi_get_gpu_memory_usage
+    mod.amdsmi_get_gpu_memory_total = amdsmi_get_gpu_memory_total
+    return mod
+
+
+@pytest.fixture()
+def fake_amdsmi(monkeypatch, setup_cleanup):
+    mod = _make_fake_amdsmi()
+    monkeypatch.setitem(sys.modules, "amdsmi", mod)
+    return mod
+
+
+@pytest.fixture()
+def backend(fake_amdsmi):
+    from perun.backend.rocmsmi import ROCMBackend
+
+    b = ROCMBackend()
+    yield b
+    b.close()
+
+
+def test_setup_metadata(backend):
+    md = backend.metadata
+    assert md["n_devices"] == 2
+    assert "amdsmi_version" in md
+
+
+def test_available_sensors_power_and_mem(backend):
+    sensors = backend.availableSensors()
+    # 2 devices * (power + mem) = 4 sensors.
+    assert len(sensors) == 4
+    assert any(s.endswith("_POWER") for s in sensors)
+    assert any(s.endswith("_MEM") for s in sensors)
+
+
+def test_available_sensors_units(backend):
+    sensors = backend.availableSensors()
+    for sensor_id, (_backend_id, dev_type, unit) in sensors.items():
+        assert dev_type == DeviceType.GPU
+        if sensor_id.endswith("_POWER"):
+            assert unit == Unit.WATT
+        elif sensor_id.endswith("_MEM"):
+            assert unit == Unit.BYTE
+
+
+def test_power_sensor_reads(backend):
+    power_id = next(s for s in backend.availableSensors() if s.endswith("_POWER"))
+    (sensor,) = backend.getSensors({power_id})
+    assert sensor.dataType.unit == Unit.WATT
+    assert int(sensor.read()) == 120
+
+
+def test_mem_sensor_reads_uint64(backend):
+    mem_id = next(s for s in backend.availableSensors() if s.endswith("_MEM"))
+    (sensor,) = backend.getSensors({mem_id})
+    value = sensor.read()
+    assert value.dtype == np.uint64
+    assert int(value) == 2048
+
+
+def test_power_callback_error_returns_zero(backend, fake_amdsmi):
+    power_id = next(s for s in backend.availableSensors() if s.endswith("_POWER"))
+    (sensor,) = backend.getSensors({power_id})
+
+    def boom(handle):
+        raise fake_amdsmi.AmdSmiException("read failure")
+
+    fake_amdsmi.amdsmi_get_power_info = boom
+    assert int(sensor.read()) == 0
+
+
+def test_close_calls_shutdown(backend, fake_amdsmi):
+    backend.close()
+    assert fake_amdsmi._state["shutdown_calls"] >= 1


### PR DESCRIPTION
## Summary

The measurement backends were effectively untested because they depend on vendor libraries (`pynvml`, `amdsmi`) and physical hardware. This PR adds unit tests that run anywhere — no GPU or specific CPU vendor required.

## Approach

- **psutil** (`test_psutil.py`): runs against the real, always-installed `psutil`; asserts sensor discovery, dtypes, units, callback bounds, and the invalid-device error path.
- **powercap_rapl** (`test_powercap_rapl.py`): builds a fake `/sys/class/powercap` tree under `tmp_path` and points the module-level `RAPL_PATH` at it. Covers package + nested DRAM discovery, sensor reads, in-place counter updates (verifying the callback re-reads the open handle), file cleanup on `close()`, and the missing-interface `ImportWarning`.
- **nvml** (`test_nvml.py`): injects a fake `pynvml` module into `sys.modules` (the backend imports it lazily via `importlib`). Covers metadata, power/mem/clock sensor discovery, reads, and error fallbacks.
- **rocmsmi** (`test_rocmsmi.py`): injects a fake `amdsmi` module. Covers metadata, power/mem sensor discovery, reads, and error fallbacks.

All fakes are torn down via the existing `setup_cleanup` fixture (which resets the backend singletons) and `monkeypatch`, so there is no cross-test contamination.

## Coverage

Backend package coverage goes from ~0% to **~78%** overall:

| module | cover |
|---|---|
| `powercap_rapl.py` | 85% |
| `rocmsmi.py` | 86% |
| `psutil.py` | 78% |
| `nvml.py` | 62% |

## Validation

Full suite: **81 passed** locally (`PATH="$PWD/.venv/bin:$PATH" pytest`). All pre-commit hooks (mypy, ruff, ruff-format) pass.