### PR TITLE
feat: friendly, non-crashing handling of missing optional dependencies

### DIFF
--- a/perun/backend/nvml.py
+++ b/perun/backend/nvml.py
@@ -1,6 +1,5 @@
 """Nvidia Mangement Library Source definition."""
 
-import importlib
 import logging
 from typing import Any, Callable
 
@@ -9,6 +8,7 @@ import numpy as np
 from perun.backend.backend import Backend
 from perun.data_model.measurement_type import Magnitude, MetricMetaData, Number, Unit
 from perun.data_model.sensor import DeviceType, Sensor
+from perun.util import optional_import
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +25,9 @@ class NVMLBackend(Backend):
 
     def setup(self) -> None:
         """Init pynvml and gather number of devices."""
-        self.pynvml = importlib.import_module("pynvml")
+        self.pynvml = optional_import(
+            "pynvml", extra="nvidia", feature="NVIDIA GPU monitoring"
+        )
         self.pynvml.nvmlInit()
         deviceCount = self.pynvml.nvmlDeviceGetCount()
         self._metadata = {

--- a/perun/backend/rocmsmi.py
+++ b/perun/backend/rocmsmi.py
@@ -1,6 +1,5 @@
 """ROCM Backend."""
 
-import importlib
 import logging
 from typing import Callable
 
@@ -9,6 +8,7 @@ import numpy as np
 from perun.backend.backend import Backend
 from perun.data_model.measurement_type import Magnitude, MetricMetaData, Number, Unit
 from perun.data_model.sensor import DeviceType, Sensor
+from perun.util import optional_import
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +25,9 @@ class ROCMBackend(Backend):
 
     def setup(self) -> None:
         """Init rocm object."""
-        self.amdsmi = importlib.import_module("amdsmi")
+        self.amdsmi = optional_import(
+            "amdsmi", extra="rocm", feature="AMD GPU monitoring"
+        )
         try:
             self.amdsmi.amdsmi_init(self.amdsmi.AmdSmiInitFlags.INIT_AMD_GPUS)
             self._metadata = {

--- a/perun/core.py
+++ b/perun/core.py
@@ -27,7 +27,13 @@ from perun.io.io import IOFormat, exportTo, importFrom
 from perun.monitoring.application import Application
 from perun.monitoring.monitor import MonitorStatus, PerunMonitor
 from perun.processing import processDataNode
-from perun.util import Singleton, filter_sensors, getRunId, increaseIdCounter
+from perun.util import (
+    MissingDependencyError,
+    Singleton,
+    filter_sensors,
+    getRunId,
+    increaseIdCounter,
+)
 from perun.version import __version__
 
 log = logging.getLogger(__name__)
@@ -111,12 +117,19 @@ class Perun(metaclass=Singleton):
                 try:
                     backend_instance = backend_class()
                     self._backends[backend_instance.id] = backend_instance
+                except MissingDependencyError as mde:
+                    # Optional dependency missing: record an actionable hint but
+                    # never crash. The backend is simply skipped. Logged at info
+                    # level so it does not pollute machine-readable stdout output
+                    # (e.g. `perun sensors`/`metadata`); raise the log level to
+                    # see it.
+                    log.info(f"Skipping backend {name}: {mde}")
                 except ImportError as ie:
                     log.info(f"Missing dependencies for backend {name}")
                     log.info(ie)
                 except Exception as e:
-                    log.error(f"Unknown error loading dependecy {name}")
-                    log.error(e)
+                    log.warning(f"Failed to initialize backend {name}, skipping it.")
+                    log.warning(e)
 
         return self._backends
 

--- a/perun/util.py
+++ b/perun/util.py
@@ -1,12 +1,97 @@
 """Util module."""
 
+import importlib
 import logging
 import os
 import re
 from datetime import datetime
+from types import ModuleType
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+
+class MissingDependencyError(ImportError):
+    """Raised when an optional dependency required for a feature is not installed.
+
+    The error message includes an actionable hint telling the user which perun
+    "extra" to install (e.g. ``pip install perun[nvidia]``) so that missing
+    optional dependencies never result in a bare, hard-to-interpret traceback.
+
+    Attributes
+    ----------
+    module : str
+        The name of the module that failed to import.
+    extra : str | None
+        The name of the perun optional-dependency extra that provides the module.
+    """
+
+    def __init__(
+        self,
+        module: str,
+        extra: str | None = None,
+        feature: str | None = None,
+    ) -> None:
+        """Build a ``MissingDependencyError`` with an actionable message.
+
+        Parameters
+        ----------
+        module : str
+            Name of the module that could not be imported.
+        extra : str | None, optional
+            Name of the perun optional-dependency extra that ships ``module``.
+            When provided, the message suggests ``pip install perun[<extra>]``.
+        feature : str | None, optional
+            Human readable name of the feature that requires the dependency,
+            used to make the message clearer.
+        """
+        self.module = module
+        self.extra = extra
+        feature_str = f" required for {feature}" if feature else ""
+        if extra:
+            hint = f"install it with `pip install perun[{extra}]`"
+        else:
+            hint = f"install it with `pip install {module}`"
+        super().__init__(
+            f"Optional dependency '{module}'{feature_str} is not installed; {hint}."
+        )
+
+
+def optional_import(
+    module: str,
+    extra: str | None = None,
+    feature: str | None = None,
+) -> ModuleType:
+    """Import an optional dependency, raising a friendly error if it is missing.
+
+    This is a thin wrapper around :func:`importlib.import_module` that converts a
+    plain :class:`ImportError`/:class:`ModuleNotFoundError` into a
+    :class:`MissingDependencyError` carrying an actionable, user-facing hint
+    about how to install the missing package.
+
+    Parameters
+    ----------
+    module : str
+        Name of the module to import.
+    extra : str | None, optional
+        Name of the perun optional-dependency extra that ships ``module``.
+    feature : str | None, optional
+        Human readable name of the feature that requires the dependency.
+
+    Returns
+    -------
+    ModuleType
+        The imported module.
+
+    Raises
+    ------
+    MissingDependencyError
+        If the module cannot be imported.
+    """
+    try:
+        return importlib.import_module(module)
+    except ImportError as e:
+        raise MissingDependencyError(module, extra=extra, feature=feature) from e
 
 
 class Singleton(type):

--- a/tests/perun/test_util.py
+++ b/tests/perun/test_util.py
@@ -1,4 +1,13 @@
-from perun.util import filter_sensors, increaseIdCounter
+import types
+
+import pytest
+
+from perun.util import (
+    MissingDependencyError,
+    filter_sensors,
+    increaseIdCounter,
+    optional_import,
+)
 
 
 def test_increaseIdCounter_no_existing_ids():
@@ -147,3 +156,45 @@ def test_filter_sensors_include_and_exclude_backends():
         sensors, include_backends=include_backends, exclude_backends=exclude_backends
     )
     assert result == {"sensor1": ("backend1",), "sensor3": ("backend1",)}
+
+
+def test_optional_import_existing_module():
+    # A module guaranteed to be importable in the test environment.
+    mod = optional_import("json")
+    assert isinstance(mod, types.ModuleType)
+    assert mod.__name__ == "json"
+
+
+def test_optional_import_missing_raises_missing_dependency_error():
+    with pytest.raises(MissingDependencyError) as excinfo:
+        optional_import("a_module_that_does_not_exist_xyz", extra="nvidia")
+    assert isinstance(excinfo.value, ImportError)
+    assert excinfo.value.module == "a_module_that_does_not_exist_xyz"
+    assert excinfo.value.extra == "nvidia"
+
+
+def test_optional_import_message_contains_install_hint():
+    with pytest.raises(MissingDependencyError) as excinfo:
+        optional_import(
+            "a_module_that_does_not_exist_xyz",
+            extra="nvidia",
+            feature="NVIDIA GPU monitoring",
+        )
+    message = str(excinfo.value)
+    assert "pip install perun[nvidia]" in message
+    assert "NVIDIA GPU monitoring" in message
+    assert "a_module_that_does_not_exist_xyz" in message
+
+
+def test_optional_import_message_without_extra_uses_module_name():
+    with pytest.raises(MissingDependencyError) as excinfo:
+        optional_import("a_module_that_does_not_exist_xyz")
+    message = str(excinfo.value)
+    assert "pip install a_module_that_does_not_exist_xyz" in message
+
+
+def test_missing_dependency_error_chains_original_import_error():
+    with pytest.raises(MissingDependencyError) as excinfo:
+        optional_import("a_module_that_does_not_exist_xyz", extra="rocm")
+    # The original ImportError is preserved as the cause for debugging.
+    assert isinstance(excinfo.value.__cause__, ImportError)


### PR DESCRIPTION
## Summary

Optional backend dependencies (`pynvml` for NVIDIA, `amdsmi` for ROCm, `mpi4py` for MPI) are installed via extras. When they are missing, perun previously logged an opaque `ImportError` with no guidance, and the failure mode was easy to misread as a crash. This PR makes missing optional dependencies **friendly and guaranteed non-crashing**.

## Changes

- **Central helper** in `perun/util.py`:
  - `MissingDependencyError` (subclass of `ImportError`) whose message includes an actionable install hint, e.g. `pip install perun[nvidia]`, and which preserves the original `ImportError` as `__cause__` for debugging.
  - `optional_import(module, extra=..., feature=...)` — a thin wrapper over `importlib.import_module` that converts a plain import failure into a `MissingDependencyError`.
- **Backends** (`nvml.py`, `rocmsmi.py`) now import their optional deps through `optional_import`, tagged with the correct perun extra (`nvidia`, `rocm`) and a human-readable feature name.
- **`Perun.backends`** catches `MissingDependencyError`, logs the actionable hint, and simply skips the backend — the run always continues with whatever backends are available.
  - The hint is logged at **info** level so it never pollutes machine-readable stdout used by `perun sensors` / `perun metadata`. Raise the log level to see it.

## Behaviour

With `pynvml` and `amdsmi` absent:

```
INFO: Skipping backend NVMLBackend: Optional dependency 'pynvml' required for NVIDIA GPU monitoring is not installed; install it with `pip install perun[nvidia]`.
INFO: Skipping backend ROCMBackend: Optional dependency 'amdsmi' required for AMD GPU monitoring is not installed; install it with `pip install perun[rocm]`.
Available backends: ['powercap_rapl', 'psutil']
```

No traceback, run proceeds normally.

## Validation

- New unit tests for `optional_import` / `MissingDependencyError` (message content, extra vs. bare hint, exception chaining).
- Verified end-to-end that a `Perun` instance with missing optional deps returns only available backends and never raises.
- Full test suite passes; all pre-commit hooks (mypy, ruff, ruff-format) pass.