### PR TITLE
feat(monitor): warn when sensor read is slower than sampling period

### DIFF
--- a/perun/monitoring/monitor.py
+++ b/perun/monitoring/monitor.py
@@ -17,7 +17,12 @@ from perun.backend.backend import Backend
 from perun.comm import Comm
 from perun.data_model.data import DataNode, LocalRegions, NodeType
 from perun.data_model.measurement_type import Number
-from perun.monitoring.subprocess import createNode, perunSubprocess, prepSensors
+from perun.monitoring.subprocess import (
+    _warnOnSlowRead,
+    createNode,
+    perunSubprocess,
+    prepSensors,
+)
 from perun.processing import (
     AggregateType,
     Magnitude,
@@ -334,12 +339,15 @@ class PerunMonitor:
         starttime_ns = time.perf_counter_ns()
         process = Popen([self._app.name, *self._app.args])
 
+        warned = False
+
         timesteps.append(starttime_ns)
         for idx, device in enumerate(lSensors):
             rawValues[idx].append(device.read())
 
         exitCode = process.poll()
         delta = (time.perf_counter_ns() - timesteps[-1]) * 1e-9
+        warned = _warnOnSlowRead(delta, sampling_period, warned)
 
         while not isinstance(exitCode, int):
             time.sleep(max(sampling_period - delta, 0.0))
@@ -349,6 +357,7 @@ class PerunMonitor:
 
             exitCode = process.poll()
             delta = (time.perf_counter_ns() - timesteps[-1]) * 1e-9
+            warned = _warnOnSlowRead(delta, sampling_period, warned)
 
         endtime_ns = time.perf_counter_ns()
         timesteps.append(time.perf_counter_ns())

--- a/perun/monitoring/subprocess.py
+++ b/perun/monitoring/subprocess.py
@@ -66,16 +66,59 @@ def prepSensors(
     return t_metadata, lSensors
 
 
+def _warnOnSlowRead(delta: float, sampling_period: float, warned: bool) -> bool:
+    """Warn once if reading the sensors takes longer than the sampling period.
+
+    A read that is slower than the configured sampling period means perun cannot
+    keep up with the requested sampling rate: sampling drifts and too much data is
+    being collected per step. The most common cause is having too many sensors
+    enabled.
+
+    Parameters
+    ----------
+    delta : float
+        Time it took to read all sensors, in seconds.
+    sampling_period : float
+        Configured sampling period, in seconds.
+    warned : bool
+        Whether the warning has already been emitted for the current run.
+
+    Returns
+    -------
+    bool
+        Updated ``warned`` flag (``True`` once the warning has been emitted).
+    """
+    if not warned and delta > sampling_period:
+        log.warning(
+            "Reading the sensors took %.3fs, which is longer than the sampling "
+            "period of %.3fs. perun cannot keep up with the requested sampling "
+            "rate and is collecting more data than it can handle. This is usually "
+            "caused by having too many sensors enabled. Consider filtering the "
+            "sensors or backends being monitored, either through the configuration "
+            "file (the 'include_sensors', 'exclude_sensors', 'include_backends' "
+            "and 'exclude_backends' options in the '[monitor]' section) or the "
+            "equivalent command line flags (--include-sensors, --exclude-sensors, "
+            "--include-backends, --exclude-backends). Alternatively, increase the "
+            "sampling period with --sampling-period.",
+            delta,
+            sampling_period,
+        )
+        return True
+    return warned
+
+
 def _monitoringLoop(
     lSensors: list[Sensor],
     timesteps: list[int],
     rawValues: list[list[Number]],
     stopCondition: Callable[[float], bool],
+    sampling_period: float,
     callbacks: list[Callable[[dict[str, Number]], None]] = [],
 ) -> None:
     timesteps.append(time.perf_counter_ns())
     values: dict[str, Number] = {}
     hostname = platform.node()
+    warned = False
     for idx, device in enumerate(lSensors):
         value = device.read()
         rawValues[idx].append(value)
@@ -85,6 +128,7 @@ def _monitoringLoop(
         callback(values)
 
     delta = (time.perf_counter_ns() - timesteps[-1]) * 1e-9
+    warned = _warnOnSlowRead(delta, sampling_period, warned)
     while not stopCondition(delta):
         timesteps.append(time.perf_counter_ns())
         for idx, device in enumerate(lSensors):
@@ -95,6 +139,7 @@ def _monitoringLoop(
         for callback in callbacks:
             callback(values)
         delta = (time.perf_counter_ns() - timesteps[-1]) * 1e-9
+        warned = _warnOnSlowRead(delta, sampling_period, warned)
 
     timesteps.append(time.perf_counter_ns())
     for idx, device in enumerate(lSensors):
@@ -265,6 +310,7 @@ def perunSubprocess(
                 timesteps,
                 rawValues,
                 lambda delta: stop_event.wait(sampling_period - delta),
+                sampling_period,
                 callbacks,
             )
             stop_event.clear()

--- a/tests/perun/monitoring/test_subprocess.py
+++ b/tests/perun/monitoring/test_subprocess.py
@@ -1,0 +1,37 @@
+"""Tests for the perun monitoring subprocess helpers."""
+
+import logging
+
+from perun.monitoring.subprocess import _warnOnSlowRead
+
+
+def test_warn_on_slow_read_emits_warning(caplog):
+    # A read slower than the sampling period should trigger a warning that
+    # points the user towards sensor/backend filtering.
+    with caplog.at_level(logging.WARNING, logger="perun.monitoring.subprocess"):
+        warned = _warnOnSlowRead(delta=2.0, sampling_period=1.0, warned=False)
+
+    assert warned is True
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "longer than the sampling" in message
+    assert "exclude_sensors" in message
+    assert "--exclude-sensors" in message
+
+
+def test_warn_on_slow_read_no_warning_when_fast(caplog):
+    # A read faster than the sampling period should not warn.
+    with caplog.at_level(logging.WARNING, logger="perun.monitoring.subprocess"):
+        warned = _warnOnSlowRead(delta=0.1, sampling_period=1.0, warned=False)
+
+    assert warned is False
+    assert len(caplog.records) == 0
+
+
+def test_warn_on_slow_read_only_warns_once(caplog):
+    # Once warned, subsequent slow reads must not repeat the warning.
+    with caplog.at_level(logging.WARNING, logger="perun.monitoring.subprocess"):
+        warned = _warnOnSlowRead(delta=2.0, sampling_period=1.0, warned=True)
+
+    assert warned is True
+    assert len(caplog.records) == 0


### PR DESCRIPTION
When reading all sensors takes longer than the configured sampling period, perun cannot keep up with the requested sampling rate and ends up collecting more data than it can handle. Emit a warning (once per run) explaining the situation and pointing the user to the sensor and backend filtering options, both in the configuration file and on the command line.

Applies to both the python subprocess monitoring loop and the binary application monitoring loop.